### PR TITLE
Pin EE deps and drop dpkg subversion

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -16,24 +16,39 @@ dependencies:
     ---
     collections:
       - name: awx.awx
+        version: "24.6.1"
       - name: azure.azcollection
-        version: ">=2.1.0"
+        version: "3.8.0"
       - name: amazon.aws
+        version: "10.1.1"
       - name: theforeman.foreman
+        version: "5.5.0"
       - name: google.cloud
+        version: "1.8.0"
       - name: openstack.cloud
+        version: "2.4.1"
       - name: community.vmware
+        version: "5.8.0"
       - name: community.windows
+        version: "3.0.1"
       - name: vmware.vmware
+        version: "2.3.0"
       - name: vmware.vmware_rest
+        version: "4.9.0"
       - name: paessler.prtg
         source: git+https://gitlab.com/PRTG/prtg-ansible.git#/ansible_collections/paessler/prtg
       - name: ovirt.ovirt
+        version: "3.2.1"
       - name: kubernetes.core
+        version: "6.1.0"
       - name: ansible.posix
+        version: "2.1.0"
       - name: ansible.windows
+        version: "3.2.0"
       - name: redhatinsights.insights
+        version: "1.3.0"
       - name: kubevirt.core
+        version: "2.2.3"
   system: |
     git-core [platform:rpm]
     python3.11-devel [platform:rpm compile]
@@ -41,7 +56,6 @@ dependencies:
     krb5-devel [platform:rpm compile]
     krb5-workstation [platform:rpm]
     subversion [platform:rpm]
-    subversion [platform:dpkg]
     git-lfs [platform:rpm]
     sshpass [platform:rpm]
     rsync [platform:rpm]


### PR DESCRIPTION
## Summary
- pin galaxy collection versions for reproducibility
- drop redundant dpkg subversion package

## Testing
- `yamllint execution-environment.yml`
- `ansible-builder create --file execution-environment.yml --context /tmp/ee-build`


------
https://chatgpt.com/codex/tasks/task_e_68c40c0cf9248328adc49d83e07dbc0f