### PR TITLE
chore: expand gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .tox/*
 /context
+__pycache__/
+*.pyc
+build/
+dist/
+*.egg-info


### PR DESCRIPTION
## Summary
- ignore common Python build artifacts

## Testing
- `./test-ee.sh validate` *(fails: Container runtime 'podman' not found)*
- `./test-ee.sh -r docker validate` *(fails: Container runtime 'docker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c40c133aec83288ed960268b4611e4